### PR TITLE
Update: Changes in src/xxd/xxd.c

### DIFF
--- a/src-xxd-xxd.c-updates.md
+++ b/src-xxd-xxd.c-updates.md
@@ -1,0 +1,14 @@
+This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.
+
+- [patch 9.1.0732: xxd: cannot use -b and -i together
+
+Problem:  xxd: cannot use -b and -i together
+          (Irgendwer)
+Solution: implement the missing changes
+          (Andre Chang)
+
+fixes: #15362
+closes: #15661
+
+Signed-off-by: Andre Chang <andre@augmentcode.com>
+Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/150227258d3f44b91cf21f527e4778f6cc38b160) - Sun, 15 Sep 2024 18:03:05 UTC


### PR DESCRIPTION
This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.

- [patch 9.1.0732: xxd: cannot use -b and -i together

Problem:  xxd: cannot use -b and -i together
          (Irgendwer)
Solution: implement the missing changes
          (Andre Chang)

fixes: #15362
closes: #15661

Signed-off-by: Andre Chang <andre@augmentcode.com>
Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/150227258d3f44b91cf21f527e4778f6cc38b160) - Sun, 15 Sep 2024 18:03:05 UTC
