### PR TITLE
Update: Changes in src/xxd/xxd.c

### DIFF
--- a/src-xxd-xxd.c-updates.md
+++ b/src-xxd-xxd.c-updates.md
@@ -1,0 +1,13 @@
+This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.
+
+- [patch 9.1.0793: xxd: -e does add one extra space
+
+Problem:  xxd: -e does add one extra space
+Solution: fix it, refactor and merge some code
+          (Aapo Rantalainen)
+
+fixes: #15898
+closes: #15899
+
+Signed-off-by: Aapo Rantalainen <aapo.rantalainen@gmail.com>
+Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/c73fc86bf8fe318aab41900dd92e380143211cda) - Sat, 19 Oct 2024 13:54:57 UTC


### PR DESCRIPTION
This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.

- [patch 9.1.0793: xxd: -e does add one extra space

Problem:  xxd: -e does add one extra space
Solution: fix it, refactor and merge some code
          (Aapo Rantalainen)

fixes: #15898
closes: #15899

Signed-off-by: Aapo Rantalainen <aapo.rantalainen@gmail.com>
Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/c73fc86bf8fe318aab41900dd92e380143211cda) - Sat, 19 Oct 2024 13:54:57 UTC
