### PR TITLE
Update: Changes in src/xxd/xxd.c

### DIFF
--- a/src-xxd-xxd.c-updates.md
+++ b/src-xxd-xxd.c-updates.md
@@ -1,0 +1,11 @@
+This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.
+
+- [patch 9.1.0857: xxd: --- is incorrectly recognized as end-of-options
+
+Problem:  xxd: --- is incorrectly recognized as end-of-options
+Solution: improve xxds end-of-option parser (DungSaga)
+
+closes: #9285
+
+Signed-off-by: DungSaga <dungsaga@users.noreply.github.com>
+Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/4b9fa957125e33951a4a830414ccb70172976397) - Mon, 11 Nov 2024 21:19:50 UTC


### PR DESCRIPTION
This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.

- [patch 9.1.0857: xxd: --- is incorrectly recognized as end-of-options

Problem:  xxd: --- is incorrectly recognized as end-of-options
Solution: improve xxds end-of-option parser (DungSaga)

closes: #9285

Signed-off-by: DungSaga <dungsaga@users.noreply.github.com>
Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/4b9fa957125e33951a4a830414ccb70172976397) - Mon, 11 Nov 2024 21:19:50 UTC
