### PR TITLE
Update: Changes in src/xxd/xxd.c

### DIFF
--- a/src-xxd-xxd.c-updates.md
+++ b/src-xxd-xxd.c-updates.md
@@ -1,0 +1,12 @@
+This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.
+
+- [patch 9.1.1363: style: inconsistent indentation in various files
+
+Problem:  style: inconsistent indentation in various files
+Solution: fix style, updated codestyle test
+          (Naruhiko Nishino)
+
+closes: #17254
+
+Signed-off-by: Naruhiko Nishino <naru123456789@gmail.com>
+Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/c2a9000bc1b4a2cbcfeef55450c184b16906d910) - Sun, 04 May 2025 18:05:47 UTC


### PR DESCRIPTION
This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.

- [patch 9.1.1363: style: inconsistent indentation in various files

Problem:  style: inconsistent indentation in various files
Solution: fix style, updated codestyle test
          (Naruhiko Nishino)

closes: #17254

Signed-off-by: Naruhiko Nishino <naru123456789@gmail.com>
Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/c2a9000bc1b4a2cbcfeef55450c184b16906d910) - Sun, 04 May 2025 18:05:47 UTC
