### PR TITLE
Update: Changes in src/xxd/xxd.c

### DIFF
--- a/src-xxd-xxd.c-updates.md
+++ b/src-xxd-xxd.c-updates.md
@@ -1,0 +1,12 @@
+This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.
+
+- [patch 9.1.1928: xxd: exit_with_usage() can be simplified
+
+Problem:  xxd: exit_with_usage() can be simplified
+Solution: Clean up exit_with_usage() formatting slightly
+          (Stefan Haubenthal)
+
+closes: #18813
+
+Signed-off-by: Stefan Haubenthal <polluks@sdf.org>
+Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/40699e399041508a5d42a3aaaa1474ee305b4066) - Wed, 26 Nov 2025 20:02:16 UTC


### PR DESCRIPTION
This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.

- [patch 9.1.1928: xxd: exit_with_usage() can be simplified

Problem:  xxd: exit_with_usage() can be simplified
Solution: Clean up exit_with_usage() formatting slightly
          (Stefan Haubenthal)

closes: #18813

Signed-off-by: Stefan Haubenthal <polluks@sdf.org>
Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/40699e399041508a5d42a3aaaa1474ee305b4066) - Wed, 26 Nov 2025 20:02:16 UTC
