### PR TITLE
Update: Changes in src/xxd/xxd.c

### DIFF
--- a/src-xxd-xxd.c-updates.md
+++ b/src-xxd-xxd.c-updates.md
@@ -1,0 +1,12 @@
+This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.
+
+- [patch 9.1.2083: style: wrong indentation of nested ifdefs
+
+Problem:  style: wrong indentation of nested ifdefs
+Solution: Fix indentation
+          (Hirohito Higashi)
+
+related: #19165
+
+Signed-off-by: Hirohito Higashi <h.east.727@gmail.com>
+Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/9fd2cae4827321075cef7216545e11fcd7877dcd) - Tue, 13 Jan 2026 21:14:33 UTC


### PR DESCRIPTION
This pull request notifies that there have been changes to `src/xxd/xxd.c` in the source repository.

- [patch 9.1.2083: style: wrong indentation of nested ifdefs

Problem:  style: wrong indentation of nested ifdefs
Solution: Fix indentation
          (Hirohito Higashi)

related: #19165

Signed-off-by: Hirohito Higashi <h.east.727@gmail.com>
Signed-off-by: Christian Brabandt <cb@256bit.org>](https://github.com/vim/vim/commit/9fd2cae4827321075cef7216545e11fcd7877dcd) - Tue, 13 Jan 2026 21:14:33 UTC
