### PR TITLE
Do not use `-fno-plt` on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CFLAGS ?= -std=c11 -pipe -fPIC $(OPTFLAGS) $(WARNFLAGS)
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	CFLAGS += -fstack-protector-strong -D_GNU_SOURCE -fno-plt
+	CFLAGS += -fstack-protector-strong -D_GNU_SOURCE
 else ifeq ($(OS),Windows_NT)
 	CFLAGS += -D_WIN32
 else


### PR DESCRIPTION
Clang ignores `-no-plt` flag on Darwin because the PLT is specific to ELF (and Darwin uses Mach-O). This causes the build to fail when the warning about an unused argument is turned into an error by `-Werror`.